### PR TITLE
Simplify api

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,32 +4,29 @@
 import * as program from "commander";
 
 import { ParseFileParams, parseFromFile } from "./node-parser";
+import { fileTypes } from "./statement-definitions";
 
 export function run(proc: NodeJS.Process) {
   // Parse command-line input
   program
     .version("1.0.0")
     .name("bank-schema-parser")
-    .usage("--bank <bank> --filePath <filePath> [--type <type>]")
-    .option("-b, --bank <bank>", "The bank who's statement will be parsed", /^(fnb|standardbank)$/i, false)
+    .usage("--fileType <fileType> --filePath <filePath>")
+    .option("-t, --fileType <fileType>", "The type of input file. Valid file types are: " + fileTypes.join(" "))
     .option("-f, --filePath <filePath>", "The path to the file that should be parsed")
-    .option(
-      "-t, --type <type>",
-      "Use to specify the type of input file. Can be DEFAULT, TRANSACTION_HISTORY or HANDMADE. Uses DEFAULT if the option is unspecified.",
-    )
     .parse(proc.argv);
 
-  if (!program.bank && !program.filePath) {
+  if (!program.fileType && !program.filePath) {
     program.help();
   }
 
-  if (!program.bank) {
-    console.error("Invalid bank name. Type --help for more details.");
+  if (!program.fileType) {
+    console.error("You must specify a file type. Type --help for more details.");
     proc.exit(1);
   }
 
   if (!program.filePath) {
-    console.error("Invalid bank statement file. Type --help for more details.");
+    console.error("You must specify a file path. Type --help for more details.");
     proc.exit(1);
   }
 
@@ -38,9 +35,7 @@ export function run(proc: NodeJS.Process) {
   try {
     const printJson = (s: {}) => console.log("%j", s);
 
-    parseFromFile({ bank: params.bank, type: params.type, filePath: params.filePath })
-      .then(printJson)
-      .catch(console.error);
+    parseFromFile({ fileType: params.fileType, filePath: params.filePath }).then(printJson).catch(console.error);
   } catch (e) {
     console.error(`[ERROR] ${e}`);
   }

--- a/src/node-parser.ts
+++ b/src/node-parser.ts
@@ -1,6 +1,6 @@
 import * as readline from "readline";
 import * as fs from "fs";
-import { InputFileTypes, Statement, getStatementParser, getParseFn, ParseParams } from ".";
+import { Statement, getStatementParser, getParseFn, ParseParams } from ".";
 import dedupe from "./deduplicate";
 
 // This file is split off from the main parser file to avoid import issues when pulling
@@ -9,14 +9,9 @@ import dedupe from "./deduplicate";
 /**
  * Parses a file given into a statement
  */
-export function parseFromFile({
-  bank,
-  type = InputFileTypes.Default,
-  filePath,
-  deduplicateTransactions,
-}: ParseFileParams): Promise<Statement> {
+export function parseFromFile({ fileType, filePath, deduplicateTransactions }: ParseFileParams): Promise<Statement> {
   const lines = getStatementLinesFromFile(filePath);
-  const fn = getStatementParser(getParseFn({ bank, type }), lines);
+  const fn = getStatementParser(getParseFn(fileType), lines);
   const result = fn(filePath);
   return deduplicateTransactions ? result.then(dedupe) : result;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import { getEmptyStatement } from "./statement";
 import statementDefinitions, { FileType } from "./statement-definitions";
 import dedupe from "./deduplicate";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import { getEmptyStatement } from "./statement";
 import statementDefinitions, { FileType } from "./statement-definitions";
 import dedupe from "./deduplicate";
-import { Statement } from "./types";
+import { ParsingFunction, Statement, StatementParser } from "./types";
 
 /**
  * Parses a file string into a statement
@@ -65,6 +65,3 @@ export interface ParseParams {
   fileType: FileType;
   deduplicateTransactions?: boolean;
 }
-
-export type StatementParser = (file: string) => Promise<Statement>;
-export type ParsingFunction = (line: string, memo: Statement) => Statement;

--- a/src/statement-definitions/fnbDefault.ts
+++ b/src/statement-definitions/fnbDefault.ts
@@ -1,5 +1,5 @@
 import * as moment from "moment";
-import { Banks, Statement, Transaction } from "..";
+import { Banks, Statement, Transaction } from "../types";
 import hash from "../hash";
 
 /**

--- a/src/statement-definitions/fnbDefault.ts
+++ b/src/statement-definitions/fnbDefault.ts
@@ -140,6 +140,6 @@ const getSection = (line: string) => {
 };
 
 export default {
-  fileType: "FNB-Default",
+  fileType: "FNB-Default" as const,
   parse,
-} as const;
+};

--- a/src/statement-definitions/fnbDefault.ts
+++ b/src/statement-definitions/fnbDefault.ts
@@ -9,7 +9,7 @@ import hash from "../hash";
  * @param memo - the statement with which the parsed data should be combined
  * @returns statement - the statement with more data parsed in
  */
-export default function (line: string, memo: FnbStatement): FnbStatement {
+function parse(line: string, memo: FnbStatement): FnbStatement {
   const statement = Object.assign({}, memo);
 
   try {
@@ -138,3 +138,8 @@ const getSection = (line: string) => {
 
   return StatementSection.Unknown;
 };
+
+export default {
+  fileType: "FNB-Default",
+  parse,
+} as const;

--- a/src/statement-definitions/fnbTransactionHistory.ts
+++ b/src/statement-definitions/fnbTransactionHistory.ts
@@ -80,7 +80,8 @@ const getSection = (line: string) => {
   return StatementSection.Unknown;
 };
 
+const fileType = "FNB-TransactionHistory" as const;
 export default {
-  fileType: "FNB-TransactionHistory",
+  fileType,
   parse,
-} as const;
+};

--- a/src/statement-definitions/fnbTransactionHistory.ts
+++ b/src/statement-definitions/fnbTransactionHistory.ts
@@ -9,7 +9,7 @@ import hash from "../hash";
  * @param memo - the statement with which the parsed data should be combined
  * @returns statement - the statement with more data parsed in
  */
-export default function (line: string, memo: Statement): Statement {
+function parse(line: string, memo: Statement): Statement {
   const statement = Object.assign({}, memo);
 
   try {
@@ -79,3 +79,8 @@ const getSection = (line: string) => {
 
   return StatementSection.Unknown;
 };
+
+export default {
+  fileType: "FNB-TransactionHistory",
+  parse,
+} as const;

--- a/src/statement-definitions/fnbTransactionHistory.ts
+++ b/src/statement-definitions/fnbTransactionHistory.ts
@@ -1,5 +1,5 @@
 import * as moment from "moment";
-import { Statement, Transaction, Banks } from "..";
+import { Statement, Transaction, Banks } from "../types";
 import hash from "../hash";
 
 /**

--- a/src/statement-definitions/index.ts
+++ b/src/statement-definitions/index.ts
@@ -1,17 +1,14 @@
-import { ParsingFunction } from "../parser";
 import fnbDefault from "./fnbDefault";
 import fnbTransactionHistory from "./fnbTransactionHistory";
 import standardbankDefault from "./standardbankDefault";
-import standardBankDefault from "./standardbankDefault";
 import standardbankHandmade from "./standardbankHandmade";
-import standardBankHandmade from "./standardbankHandmade";
 
 const statementDefinitions = {
   [fnbDefault.fileType]: fnbDefault.parse,
   [fnbTransactionHistory.fileType]: fnbTransactionHistory.parse,
-  [standardBankDefault.fileType]: standardbankDefault.parse,
-  [standardbankHandmade.fileType]: standardBankHandmade.parse,
-} as const;
+  [standardbankDefault.fileType]: standardbankDefault.parse,
+  [standardbankHandmade.fileType]: standardbankHandmade.parse,
+};
 
 export const fileTypes = Object.keys(statementDefinitions);
 export type FileType = keyof typeof statementDefinitions;

--- a/src/statement-definitions/index.ts
+++ b/src/statement-definitions/index.ts
@@ -1,6 +1,19 @@
-import parseFnbStatement from "./fnbStatement";
-import parseFnbTransactionHistory from "./fnbTransactionHistory";
-import parseStandardbankStatement from "./standardbankStatement";
-import parseHandmadeStandardbankStatement from "./standardbankHandmadeStatement";
+import { ParsingFunction } from "../parser";
+import fnbDefault from "./fnbDefault";
+import fnbTransactionHistory from "./fnbTransactionHistory";
+import standardbankDefault from "./standardbankDefault";
+import standardBankDefault from "./standardbankDefault";
+import standardbankHandmade from "./standardbankHandmade";
+import standardBankHandmade from "./standardbankHandmade";
 
-export { parseFnbStatement, parseFnbTransactionHistory, parseStandardbankStatement, parseHandmadeStandardbankStatement };
+const statementDefinitions = {
+  [fnbDefault.fileType]: fnbDefault.parse,
+  [fnbTransactionHistory.fileType]: fnbTransactionHistory.parse,
+  [standardBankDefault.fileType]: standardbankDefault.parse,
+  [standardbankHandmade.fileType]: standardBankHandmade.parse,
+} as const;
+
+export const fileTypes = Object.keys(statementDefinitions);
+export type FileType = keyof typeof statementDefinitions;
+
+export default statementDefinitions;

--- a/src/statement-definitions/standardbankDefault.ts
+++ b/src/statement-definitions/standardbankDefault.ts
@@ -9,7 +9,7 @@ import hash from "../hash";
  * @param memo - the statement with which the parsed data should be combined
  * @returns statement - the statement with more data parsed in
  */
-export default function(line: string, memo: StandardBankStatement): StandardBankStatement {
+function parse(line: string, memo: StandardBankStatement): StandardBankStatement {
   const statement = Object.assign({}, memo);
 
   try {
@@ -112,3 +112,8 @@ const toTimeStamp = (dateString: string) => moment(dateString).format();
 
 const toDateString = (standardBankDateString: string): string =>
   [standardBankDateString.slice(0, 4), standardBankDateString.slice(4, 6), standardBankDateString.slice(6)].join("-");
+
+export default {
+  fileType: "StandardBank-Default",
+  parse,
+} as const;

--- a/src/statement-definitions/standardbankDefault.ts
+++ b/src/statement-definitions/standardbankDefault.ts
@@ -1,4 +1,4 @@
-import { Banks, Statement, Transaction } from "..";
+import { Banks, Statement, Transaction } from "../types";
 import * as moment from "moment";
 import hash from "../hash";
 

--- a/src/statement-definitions/standardbankDefault.ts
+++ b/src/statement-definitions/standardbankDefault.ts
@@ -114,6 +114,6 @@ const toDateString = (standardBankDateString: string): string =>
   [standardBankDateString.slice(0, 4), standardBankDateString.slice(4, 6), standardBankDateString.slice(6)].join("-");
 
 export default {
-  fileType: "StandardBank-Default",
+  fileType: "StandardBank-Default" as const,
   parse,
-} as const;
+};

--- a/src/statement-definitions/standardbankHandmade.ts
+++ b/src/statement-definitions/standardbankHandmade.ts
@@ -7,7 +7,7 @@ import * as moment from "moment";
  * PDF statements have fewer overall fields, but more transaction information that regular statements
  * (notably the transactions contain balances), so a different function is required to parse them.
  */
-const parseStandardBankBackfill: ParsingFunction = function (line: string, memo: Statement): Statement {
+const parse: ParsingFunction = function (line: string, memo: Statement): Statement {
   const statement = Object.assign({}, memo);
 
   switch (getSection(line)) {
@@ -70,6 +70,6 @@ function toTimestamp(dateString: string): string {
 }
 
 export default {
-  fileType: "StandardBank-Handmade",
-  parse: parseStandardBankBackfill,
-} as const;
+  fileType: "StandardBank-Handmade" as const,
+  parse,
+};

--- a/src/statement-definitions/standardbankHandmade.ts
+++ b/src/statement-definitions/standardbankHandmade.ts
@@ -1,4 +1,4 @@
-import { Banks, Statement, Transaction, ParsingFunction } from "..";
+import { Banks, ParsingFunction, Statement, Transaction } from "../types";
 import hash from "../hash";
 import * as moment from "moment";
 

--- a/src/statement-definitions/standardbankHandmade.ts
+++ b/src/statement-definitions/standardbankHandmade.ts
@@ -69,4 +69,7 @@ function toTimestamp(dateString: string): string {
   return moment(dateString).format();
 }
 
-export default parseStandardBankBackfill;
+export default {
+  fileType: "StandardBank-Handmade",
+  parse: parseStandardBankBackfill,
+} as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,6 @@ export enum Banks {
   FNB = "fnb",
   StandardBank = "standardbank",
 }
+
+export type StatementParser = (file: string) => Promise<Statement>;
+export type ParsingFunction = (line: string, memo: Statement) => Statement;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,9 +17,3 @@ export enum Banks {
   FNB = "fnb",
   StandardBank = "standardbank",
 }
-
-export enum InputFileTypes {
-  Default = "DEFAULT",
-  Handmade = "HANDMADE",
-  TransactionHistory = "TRANSACTION_HISTORY",
-}

--- a/tst/fnb.test.ts
+++ b/tst/fnb.test.ts
@@ -1,5 +1,5 @@
 import { validateTransaction } from "bank-schema";
-import fnb, { FnbStatement } from "../src/statement-definitions/fnbStatement";
+import fnb, { FnbStatement } from "../src/statement-definitions/fnbDefault";
 import { getEmptyStatement } from "../src/statement";
 
 describe("fnb", () => {
@@ -10,7 +10,7 @@ describe("fnb", () => {
     statement.startDate = new Date("2019");
     statement.endDate = new Date("2020");
 
-    const parsedTransaction = fnb(transactionLine, statement).transactions[0];
+    const parsedTransaction = fnb.parse(transactionLine, statement).transactions[0];
 
     expect(validateTransaction(parsedTransaction).valid).toBeTruthy();
     expect(parsedTransaction.amountInZAR).toEqual(150);
@@ -26,7 +26,7 @@ describe("fnb", () => {
     // this transaction could not have happened in 2019 - that's before the start of the statement date range
     const transactionLine = `5,35,'2 Jan',"foo","bar","baz",150,1000`;
 
-    const parsedTransaction = fnb(transactionLine, statement).transactions[0];
+    const parsedTransaction = fnb.parse(transactionLine, statement).transactions[0];
 
     expect(parsedTransaction.timeStamp).toEqual("2020-01-02T00:00:00+02:00");
   });

--- a/tst/fnb.test.ts
+++ b/tst/fnb.test.ts
@@ -1,6 +1,6 @@
 import { validateTransaction } from "bank-schema";
-import fnb, { FnbStatement } from "../src/statement-definitions/fnbDefault";
 import { getEmptyStatement } from "../src/statement";
+import definition, { FnbStatement } from "../src/statement-definitions/fnbDefault";
 
 describe("fnb", () => {
   it("parses a transaction from a statement", () => {
@@ -10,7 +10,7 @@ describe("fnb", () => {
     statement.startDate = new Date("2019");
     statement.endDate = new Date("2020");
 
-    const parsedTransaction = fnb.parse(transactionLine, statement).transactions[0];
+    const parsedTransaction = definition.parse(transactionLine, statement).transactions[0];
 
     expect(validateTransaction(parsedTransaction).valid).toBeTruthy();
     expect(parsedTransaction.amountInZAR).toEqual(150);
@@ -26,7 +26,7 @@ describe("fnb", () => {
     // this transaction could not have happened in 2019 - that's before the start of the statement date range
     const transactionLine = `5,35,'2 Jan',"foo","bar","baz",150,1000`;
 
-    const parsedTransaction = fnb.parse(transactionLine, statement).transactions[0];
+    const parsedTransaction = definition.parse(transactionLine, statement).transactions[0];
 
     expect(parsedTransaction.timeStamp).toEqual("2020-01-02T00:00:00+02:00");
   });

--- a/tst/fnbTransactionHistory.test.ts
+++ b/tst/fnbTransactionHistory.test.ts
@@ -1,5 +1,5 @@
 import { validateTransaction } from "bank-schema";
-import parse from "../src/statement-definitions/fnbTransactionHistory";
+import fnb from "../src/statement-definitions/fnbTransactionHistory";
 import { getEmptyStatement } from "../src/statement";
 import { Statement } from "../src/types";
 
@@ -7,7 +7,7 @@ describe("fnb", () => {
   it("parses a transaction from a statement", () => {
     const transactionLine = `2019/08/01, -438.00, 82875.21, VIRGIN ACT4003863716:169314`;
     const statement: Statement = getEmptyStatement();
-    const parsedTransaction = parse(transactionLine, statement).transactions[0];
+    const parsedTransaction = fnb.parse(transactionLine, statement).transactions[0];
 
     expect(validateTransaction(parsedTransaction).valid).toBeTruthy();
     expect(parsedTransaction.amountInZAR).toEqual(-438);

--- a/tst/fnbTransactionHistory.test.ts
+++ b/tst/fnbTransactionHistory.test.ts
@@ -1,13 +1,13 @@
 import { validateTransaction } from "bank-schema";
-import fnb from "../src/statement-definitions/fnbTransactionHistory";
 import { getEmptyStatement } from "../src/statement";
+import definition from "../src/statement-definitions/fnbTransactionHistory";
 import { Statement } from "../src/types";
 
 describe("fnb", () => {
   it("parses a transaction from a statement", () => {
     const transactionLine = `2019/08/01, -438.00, 82875.21, VIRGIN ACT4003863716:169314`;
     const statement: Statement = getEmptyStatement();
-    const parsedTransaction = fnb.parse(transactionLine, statement).transactions[0];
+    const parsedTransaction = definition.parse(transactionLine, statement).transactions[0];
 
     expect(validateTransaction(parsedTransaction).valid).toBeTruthy();
     expect(parsedTransaction.amountInZAR).toEqual(-438);

--- a/tst/standardbank.test.ts
+++ b/tst/standardbank.test.ts
@@ -1,6 +1,6 @@
 import { validateTransaction } from "bank-schema";
 import { getEmptyStatement } from "../src/statement";
-import standardbank, { StandardBankStatement } from "../src/statement-definitions/standardbankStatement";
+import standardbank, { StandardBankStatement } from "../src/statement-definitions/standardbankDefault";
 
 describe("standardbank", () => {
   it("parses a transaction from a statement", () => {
@@ -8,7 +8,7 @@ describe("standardbank", () => {
 
     const statement: StandardBankStatement = getEmptyStatement();
     statement.runningBalance = 100;
-    const parsedTransaction = standardbank(transactionLine, statement).transactions[0];
+    const parsedTransaction = standardbank.parse(transactionLine, statement).transactions[0];
 
     expect(validateTransaction(parsedTransaction).valid).toBeTruthy();
     expect(parsedTransaction.amountInZAR).toEqual(-150);
@@ -25,7 +25,7 @@ describe("standardbank", () => {
     ];
 
     let statement: StandardBankStatement = getEmptyStatement();
-    lines.forEach(line => (statement = standardbank(line, statement)));
+    lines.forEach((line) => (statement = standardbank.parse(line, statement)));
 
     expect(statement.runningBalance).toEqual(1100.21);
   });

--- a/tst/standardbank.test.ts
+++ b/tst/standardbank.test.ts
@@ -1,6 +1,6 @@
 import { validateTransaction } from "bank-schema";
 import { getEmptyStatement } from "../src/statement";
-import standardbank, { StandardBankStatement } from "../src/statement-definitions/standardbankDefault";
+import definition, { StandardBankStatement } from "../src/statement-definitions/standardbankDefault";
 
 describe("standardbank", () => {
   it("parses a transaction from a statement", () => {
@@ -8,7 +8,7 @@ describe("standardbank", () => {
 
     const statement: StandardBankStatement = getEmptyStatement();
     statement.runningBalance = 100;
-    const parsedTransaction = standardbank.parse(transactionLine, statement).transactions[0];
+    const parsedTransaction = definition.parse(transactionLine, statement).transactions[0];
 
     expect(validateTransaction(parsedTransaction).valid).toBeTruthy();
     expect(parsedTransaction.amountInZAR).toEqual(-150);
@@ -25,7 +25,7 @@ describe("standardbank", () => {
     ];
 
     let statement: StandardBankStatement = getEmptyStatement();
-    lines.forEach((line) => (statement = standardbank.parse(line, statement)));
+    lines.forEach((line) => (statement = definition.parse(line, statement)));
 
     expect(statement.runningBalance).toEqual(1100.21);
   });

--- a/tst/standardbankHandmade.test.ts
+++ b/tst/standardbankHandmade.test.ts
@@ -1,18 +1,18 @@
 import { validateTransaction } from "bank-schema";
-import parsingFunction from "../src/statement-definitions/standardbankHandmadeStatement";
+import standardBank from "../src/statement-definitions/standardbankHandmade";
 import { getEmptyStatement } from "../src/statement";
 
 describe("standardBankBackfill", () => {
   it("extracts the account name", () => {
     const line = "ACCOUNT,10092563862,,,";
 
-    const statement = parsingFunction(line, getEmptyStatement());
+    const statement = standardBank.parse(line, getEmptyStatement());
     expect(statement.account).toEqual("10092563862");
   });
 
   it("parses the transactions", () => {
     const line = "HIST,MAGTAPE CREDIT TEST TRANSFER,500.00,2017-07-26,130500.00";
-    const transaction = parsingFunction(line, getEmptyStatement()).transactions[0];
+    const transaction = standardBank.parse(line, getEmptyStatement()).transactions[0];
 
     expect(validateTransaction(transaction).valid).toBeTruthy();
     expect(transaction.amountInZAR).toEqual(500);

--- a/tst/standardbankHandmade.test.ts
+++ b/tst/standardbankHandmade.test.ts
@@ -1,18 +1,18 @@
 import { validateTransaction } from "bank-schema";
-import standardBank from "../src/statement-definitions/standardbankHandmade";
 import { getEmptyStatement } from "../src/statement";
+import definition from "../src/statement-definitions/standardbankHandmade";
 
 describe("standardBankBackfill", () => {
   it("extracts the account name", () => {
     const line = "ACCOUNT,10092563862,,,";
 
-    const statement = standardBank.parse(line, getEmptyStatement());
+    const statement = definition.parse(line, getEmptyStatement());
     expect(statement.account).toEqual("10092563862");
   });
 
   it("parses the transactions", () => {
     const line = "HIST,MAGTAPE CREDIT TEST TRANSFER,500.00,2017-07-26,130500.00";
-    const transaction = standardBank.parse(line, getEmptyStatement()).transactions[0];
+    const transaction = definition.parse(line, getEmptyStatement()).transactions[0];
 
     expect(validateTransaction(transaction).valid).toBeTruthy();
     expect(transaction.amountInZAR).toEqual(500);


### PR DESCRIPTION
This change combines both the bank and file type into a single parameter and surfaces some auto-generated types and data structures.

The goal is to make both CLI and UI experiences simpler to use/maintain and to break the need for real banks to be defined for a filetype to be valid: e.g. raw bank-schema data doesn't need to have a bank passed in as the bank is already encoded in the data.

### Testing 

- Unit tests still work
- Running the CLI against known data works as expected.

```
npm run parse -- -t FNB-Default -f ~/Downloads/62206800767\ \(1\).csv
{expected json output}
```